### PR TITLE
use a partial lookup on the secondary rate limit check

### DIFF
--- a/github_ratelimit/detect.go
+++ b/github_ratelimit/detect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type SecondaryRateLimitBody struct {
@@ -13,12 +14,12 @@ type SecondaryRateLimitBody struct {
 }
 
 const (
-	SecondaryRateLimitMessage          = `You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.`
+	SecondaryRateLimitMessage          = `You have exceeded a secondary rate limit`
 	SecondaryRateLimitDocumentationURL = `https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits`
 )
 
 func (s SecondaryRateLimitBody) IsSecondaryRateLimit() bool {
-	return s.Message == SecondaryRateLimitMessage && s.DocumentURL == SecondaryRateLimitDocumentationURL
+	return strings.Contains(s.Message, SecondaryRateLimitMessage) && s.DocumentURL == SecondaryRateLimitDocumentationURL
 }
 
 // isSecondaryRateLimit checks whether the response is a legitimate secondary rate limit.


### PR DESCRIPTION
The error message from github has changed it now looks like 
```You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later. If you reach out to GitHub Support for help, please include the request ID <token>```

Make this more resliatant to github changing things. 

I am tempted not to worry about getting this merged into upstream as there is another user already on the topic for a different reason. My logic is just pop it into our fork and leave ourselves pointed at our fork until upstream has its fix. 

(obvioulsy if we don't get an updated PR on upstream relatively quickly we can pull this into it) 

This was tested ... here https://github.com/fac/terra-module-updater/actions/runs/6380378068


Will need us to merge  https://github.com/fac/terra-module-updater/pull/24 (with a change just just use 'main' of our fork rather than the branch) once this is merged. 